### PR TITLE
Adiciona ao WidgetEmbedded test Capacidade de renderizar envelopes

### DIFF
--- a/embedded.js
+++ b/embedded.js
@@ -5,6 +5,7 @@ function Clicksign(key, is_not_legacy) {
       endpoint = 'https://app.clicksign.com',
       origin = window.location.protocol + '//' + window.location.host,
       listen = {};
+
   var mount = function (id) {
     var BASE_PATH = is_not_legacy ? '/notarial/compat/requests/' : '/sign/';
     var path = BASE_PATH + key,

--- a/embedded.js
+++ b/embedded.js
@@ -1,13 +1,14 @@
-function Clicksign(key) {
+function Clicksign(key, is_not_legacy) {
   "use strict";
 
   var iframe, target,
       endpoint = 'https://app.clicksign.com',
       origin = window.location.protocol + '//' + window.location.host,
       listen = {};
-
+      
   var mount = function (id) {
-    var path = '/sign/' + key,
+    var BASE_PATH = is_not_legacy ? '/notarial/compat/requests/' : '/sign/';
+    var path = BASE_PATH + key,
         params = '?embedded=true&origin=' + this.origin,
         src = this.endpoint + path + params;
 

--- a/embedded.js
+++ b/embedded.js
@@ -5,7 +5,6 @@ function Clicksign(key, is_not_legacy) {
       endpoint = 'https://app.clicksign.com',
       origin = window.location.protocol + '//' + window.location.host,
       listen = {};
-      
   var mount = function (id) {
     var BASE_PATH = is_not_legacy ? '/notarial/compat/requests/' : '/sign/';
     var path = BASE_PATH + key,

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         input = document.getElementById('request_signature_key'),
         environment = document.getElementById('request_enviroment');
 
-      const ENVIRONMENTS_COUNT = 10;
+      const ENVIRONMENTS_COUNT = 18;
       for (let index = 1; index <= ENVIRONMENTS_COUNT; index++) {
         let option = document.createElement('option');
         option.text = `Staging ${index}`;

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
             <option value="https://app.clicksign.com">Produção</option>
           </select>
         </div>
+        <div class="field legacy">
+          <input id="request_legacy" type="checkbox" value="true">
+          <label for="request_legacy"> Is Batch? (Legacy) </label>
+        </div>
         <div class="action">
           <button id="setButton" type="submit" class="button" onclick="setWidget()">
             Carregar
@@ -38,6 +42,7 @@
     <script type="text/javascript">
       let widget,
         input = document.getElementById('request_signature_key'),
+        legacy_checkbox = document.getElementById('request_legacy'),
         environment = document.getElementById('request_enviroment');
 
       const ENVIRONMENTS_COUNT = 18;
@@ -49,11 +54,12 @@
       }
 
       function setWidget() {
-        let request_signature_key = input.value;
+        let request_signature_key = input.value,
+          is_not_legacy = !legacy_checkbox.checked;
 
         try {
           if (widget) widget.unmount();
-          widget = new Clicksign(request_signature_key);
+          widget = new Clicksign(request_signature_key, is_not_legacy);
           widget.endpoint = environment.value;
           widget.origin = window.location.href;
           widget.mount('widget');

--- a/style.css
+++ b/style.css
@@ -105,12 +105,14 @@ button[disabled] {
 
 /* MAIN */
 .main {
-  margin: 0 16px;
-
+  margin: 16px;
 }
 
 iframe {
+  display: block;
   border: none;
+  padding: 0;
+  margin: 0;
 }
 
 .container {
@@ -120,6 +122,6 @@ iframe {
   color: #999;
   font-size: 18px;
   background: #fafafa;
-  min-height: calc(100vh - 170px);
+  min-height: calc(100vh - 182px);
   border-radius: 8px;
 }

--- a/style.css
+++ b/style.css
@@ -36,7 +36,6 @@ select {
   border: 1px solid #e5e5e5;
   padding: 8px 12px;
   border-radius: 4px;
-  margin-bottom: 20px;
   width: 100%;
   height: 36px;
   box-sizing: border-box;
@@ -89,18 +88,21 @@ button[disabled] {
   position: sticky;
   padding: 8px 24px;
   display: flex;
-  align-items: flex-end;
-  gap: 16px;
+  flex-wrap: wrap;
+  column-gap: 16px;
+  row-gap: 8px;
   background: #e6eeff;
   border-radius: 8px;
 }
 
 .settings .batch-key {
   flex: 1;
+  min-width: 50%;
 }
 
-.settings .action button {
-  margin-bottom: 20px;
+.settings .field.legacy {
+  min-width: 50%;
+  flex: 1;
 }
 
 /* MAIN */

--- a/tokenless/index.html
+++ b/tokenless/index.html
@@ -36,6 +36,10 @@
     <form id="form" action="success.html" onsubmit="return false">
       <filedset class="signer-info">
         <div class="field">
+          <label>Nome</label><br>
+          <input type="text" id="name" name="name" />
+        </div>
+        <div class="field">
           <label>CPF</label><br>
           <input type="text" id="cpf" name="cpf" />
         </div>
@@ -76,6 +80,7 @@
       tw.attach('click', 'submitButton', () => {
         const data = {
           "signature": {
+            "name": document.getElementById("name").value,
             "birthday": document.getElementById("birthdate").value,
             "documentation": document.getElementById("cpf").value
           }


### PR DESCRIPTION
### Descrição

Não era possível testar envelopes embedded através do widget embedded test, então para isso foi criada uma regra para renderizar uma url diferente, quando necessário.

### Screenshots (para mudanças de UI, se houver)

![image](https://user-images.githubusercontent.com/76953000/200881767-a7ccab1f-8163-403f-94e4-9c1f60d197b0.png)

### Checklist para poder mergear

- [ ] O código do PR inclui (ou já possui) testes para o código nele
- [ ] Os checks de linters estão passando
- [ ] Os checks de testes estão passando
