### PR TITLE
Liberar geolocalização no Widget Embedded

### DIFF
--- a/embedded.js
+++ b/embedded.js
@@ -16,7 +16,7 @@ function Clicksign(key) {
     iframe = document.createElement('iframe');
     iframe.setAttribute('src', src);
     iframe.setAttribute('style', 'width: 100%; height: 100%;');
-    iframe.setAttribute('allow', 'camera');
+    iframe.setAttribute('allow', 'camera;geolocation');
 
     window.addEventListener('message', handle);
 

--- a/embedded.js
+++ b/embedded.js
@@ -16,7 +16,7 @@ function Clicksign(key) {
     iframe = document.createElement('iframe');
     iframe.setAttribute('src', src);
     iframe.setAttribute('style', 'width: 100%; height: 100%;');
-    iframe.setAttribute('allow', 'camera;geolocation');
+    iframe.setAttribute('allow', 'camera; geolocation');
 
     window.addEventListener('message', handle);
 


### PR DESCRIPTION
### Descrição

Para funcionar a geolocalização do signatário na hora de assinar que foi implementada nesse [CARD](https://clicksign.kanbanize.com/ctrl_board/141/cards/23585/details/) é necessário fazer uma pequena alteração no widget embedded para permitir que o iframe capture a geolocalização do signatário.

### Issue tracker

[Card](https://clicksign.kanbanize.com/ctrl_board/141/cards/23935/details/)

### Code Review

Como fazer o Code Review:

[CONTRIBUTING.md](https://github.com/clicksign/.github/blob/8d623c886c2da0266d108d5fa21cf01a1c82cbc0/CONTRIBUTING.md)

### Checklist para poder mergear

- [ ] O código do PR inclui (ou já possui) testes para o código nele
- [ ] Os checks de linters estão passando
- [ ] Os checks de testes estão passando
